### PR TITLE
Removing agnostic links and adding strict https://. 

### DIFF
--- a/resources/templates/_pattern-kit-app.twig
+++ b/resources/templates/_pattern-kit-app.twig
@@ -9,8 +9,8 @@
 <head>
   <title></title>
     <meta charset="utf-8">
- <!-- Foundation CSS framework (Bootstrap and jQueryUI also supported) -->
-    <link rel="stylesheet" id="theme_stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css">
+    <!-- Foundation CSS framework (Bootstrap and jQueryUI also supported) -->
+    <link rel="stylesheet" id="theme_stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css">
     <!-- Font Awesome icons (Bootstrap, Foundation, and jQueryUI also supported) -->
     <link rel='stylesheet' href='//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.0.3/css/font-awesome.css'>
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -20,12 +20,12 @@
     <script type="text/javascript" src="{{vendor_path}}web/js/json-editor.js"></script>
     <script type="text/javascript" src="{{vendor_path}}web/js/lzstring.js"></script>
     <script src="//cdn.jsdelivr.net/interact.js/1.2.6/interact.min.js"></script>
-    <script type="text/javascript" src="//netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="https://netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
     <script src="//cdn.jsdelivr.net/sceditor/1.4.3/jquery.sceditor.bbcode.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.0/ace.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.0/mode-html.js"></script>
-    <script src="//cdn.jsdelivr.net/sceditor/1.4.3/jquery.sceditor.xhtml.min.js"></script>
-    <link rel="stylesheet" href="//cdn.jsdelivr.net/sceditor/1.4.3/themes/default.min.css">
+    <script src="https://cdn.jsdelivr.net/sceditor/1.4.3/jquery.sceditor.xhtml.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/sceditor/1.4.3/themes/default.min.css">
 
 </head>
 <body>

--- a/resources/templates/_pattern-kit-app.twig
+++ b/resources/templates/_pattern-kit-app.twig
@@ -19,9 +19,9 @@
     <script type="text/javascript" src="http://code.jquery.com/jquery-1.11.3.min.js"></script>
     <script type="text/javascript" src="{{vendor_path}}web/js/json-editor.js"></script>
     <script type="text/javascript" src="{{vendor_path}}web/js/lzstring.js"></script>
-    <script src="//cdn.jsdelivr.net/interact.js/1.2.6/interact.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/interact.js/1.2.6/interact.min.js"></script>
     <script type="text/javascript" src="https://netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
-    <script src="//cdn.jsdelivr.net/sceditor/1.4.3/jquery.sceditor.bbcode.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/sceditor/1.4.3/jquery.sceditor.bbcode.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.0/ace.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.0/mode-html.js"></script>
     <script src="https://cdn.jsdelivr.net/sceditor/1.4.3/jquery.sceditor.xhtml.min.js"></script>


### PR DESCRIPTION
This resolves a problem where the pages are failing to load, taking too much time to lookup cdn resources. Setting to strict HTTPS instead of agnostic seem to resolve the issue. 