### PR TITLE
Update pk-config to support a dropdown for full page previews

### DIFF
--- a/.pk-config.yml
+++ b/.pk-config.yml
@@ -21,12 +21,12 @@ extensions:
   docs: .docs.md
   sg: .sg.md
 categories:
-    - Pages
-    - Patterns
-    - Subpatterns
-    - Layouts
-    - Components
-    - Atoms
+    - Page
+    - Pattern
+    - Subpattern
+    - Layout
+    - Component
+    - Atom
 assets:
   css:
   js:

--- a/.pk-config.yml
+++ b/.pk-config.yml
@@ -21,11 +21,12 @@ extensions:
   docs: .docs.md
   sg: .sg.md
 categories:
-    - Pattern
-    - Sub Pattern
-    - Layout
-    - Component
-    - Atom
+    - Pages
+    - Patterns
+    - Subpatterns
+    - Layouts
+    - Components
+    - Atoms
 assets:
   css:
   js:


### PR DESCRIPTION
Update config to support a dropdown for full page previews to separate them for users from the individual patterns.  This gives clarity to users that these full page mock-ups are unique and helps to visually differentiate them from the list of individual patterns that make up the page patterns.