### PR TITLE
Extend window resizer handles for longer pages

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -3,6 +3,7 @@ Tag: [1.5](https://github.com/PatternBuilder/pattern-kit/releases/tag/V1.5)
 
 - Add support for body attributes in the config
 - Update documentation
+- Update styles for squishy-window indicators for usability
 
 ## 1.4 Code refactor and changes to allow assets to track with the module.
 Tag: [1.4](https://github.com/PatternBuilder/pattern-kit/releases/tag/V1.4)

--- a/web/css/json-editor.css
+++ b/web/css/json-editor.css
@@ -111,7 +111,10 @@ a:hover, a:focus {
 .sg-snippet-resize-handle.pos-right {
     border-right: 1px solid #ccc;
     left: -40px;
-    cursor: e-resize
+    cursor: e-resize;
+    background: #f8f4fe;
+    height: 98%;
+    top: 1%;
 }
 
 .sg-snippet-resize-handle.pos-right:before {
@@ -121,7 +124,10 @@ a:hover, a:focus {
 .sg-snippet-resize-handle.pos-left {
     border-left: 1px solid #ccc;
     cursor: w-resize;
-    right: -40px
+    right: -40px;
+    background: #f8f4fe;
+    height: 98%;
+    top: 1%;
 }
 
 .sg-snippet-resize-handle.pos-left:before {

--- a/web/css/json-editor.css
+++ b/web/css/json-editor.css
@@ -1,86 +1,86 @@
 /* Define Overpass font */
 @font-face {
-    font-family: Overpass;
-    src: url("/resources/fixtures/fonts/overpass_regular-web.eot");
-    src: url("/resources/fixtures/fonts/overpass_regular-web.eot?#iefix") format("eot"),
-         url("/resources/fixtures/fonts/overpass_regular-web.woff") format("woff"),
-         url("/resources/fixtures/fonts/overpass_regular-web.ttf") format("truetype"),
-         url("/resources/fixtures/fonts/overpass_regular-web.svg#webfontLTZe4IYH") format("svg");
-    font-weight: 600;
-    font-style: normal;
+  font-family: Overpass;
+  src: url("/resources/fixtures/fonts/overpass_regular-web.eot");
+  src: url("/resources/fixtures/fonts/overpass_regular-web.eot?#iefix") format("eot"),
+       url("/resources/fixtures/fonts/overpass_regular-web.woff") format("woff"),
+       url("/resources/fixtures/fonts/overpass_regular-web.ttf") format("truetype"),
+       url("/resources/fixtures/fonts/overpass_regular-web.svg#webfontLTZe4IYH") format("svg");
+  font-weight: 600;
+  font-style: normal;
 }
 
 @font-face {
-    font-family: Overpass;
-    src: url("/resources/fixtures/fonts/overpass_bold-web.eot");
-    src: url("/resources/fixtures/fonts/overpass_bold-web.eot?#iefix") format("eot"),
-         url("/resources/fixtures/fonts/overpass_bold-web.woff") format("woff"),
-         url("/resources/fixtures/fonts/overpass_bold-web.ttf") format("truetype"),
-         url("/resources/fixtures/fonts/overpass_bold-web.svg#webfontzAU82Ltw") format("svg");
-    font-weight: 800;
-    font-style: normal;
+  font-family: Overpass;
+  src: url("/resources/fixtures/fonts/overpass_bold-web.eot");
+  src: url("/resources/fixtures/fonts/overpass_bold-web.eot?#iefix") format("eot"),
+       url("/resources/fixtures/fonts/overpass_bold-web.woff") format("woff"),
+       url("/resources/fixtures/fonts/overpass_bold-web.ttf") format("truetype"),
+       url("/resources/fixtures/fonts/overpass_bold-web.svg#webfontzAU82Ltw") format("svg");
+  font-weight: 800;
+  font-style: normal;
 }
 
 @font-face {
-    font-family: Overpass;
-    src: url("/resources/fixtures/fonts/overpass_light-webfont.eot");
-    src: url("/resources/fixtures/fonts/overpass_light-webfont.eot?#iefix") format("eot"),
-         url("/resources/fixtures/fonts/overpass_light-webfont.woff") format("woff"),
-         url("/resources/fixtures/fonts/overpass_light-webfont.ttf") format("truetype"),
-         url("/resources/fixtures/fonts/overpass_light-webfont.svg#webfontzAU82Ltw") format("svg");
-    font-weight: 400;
-    font-style: normal;
+  font-family: Overpass;
+  src: url("/resources/fixtures/fonts/overpass_light-webfont.eot");
+  src: url("/resources/fixtures/fonts/overpass_light-webfont.eot?#iefix") format("eot"),
+       url("/resources/fixtures/fonts/overpass_light-webfont.woff") format("woff"),
+       url("/resources/fixtures/fonts/overpass_light-webfont.ttf") format("truetype"),
+       url("/resources/fixtures/fonts/overpass_light-webfont.svg#webfontzAU82Ltw") format("svg");
+  font-weight: 400;
+  font-style: normal;
 }
 body {
-    font-size: 16px;
-    font-family: "Overpass", Overpass, Helvetica, helvetica, arial, sans-serif;
-    font-weight: 100;
+  font-size: 16px;
+  font-family: "Overpass", Overpass, Helvetica, helvetica, arial, sans-serif;
+  font-weight: 100;
 }
 
 h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
-  font-family: "Overpass", Overpass, Helvetica, helvetica, arial, sans-serif;
-  color: #017EA3;
-  font-weight: 400;
+font-family: "Overpass", Overpass, Helvetica, helvetica, arial, sans-serif;
+color: #017EA3;
+font-weight: 400;
 }
 h1, .h1 {
-  color: #02546d;
+color: #02546d;
 }
 h1, .h1, h2, .h2 {
-  font-weight: 600;
+font-weight: 600;
 }
 a {
-  color: #017EA3;
+color: #017EA3;
 }
 a:hover, a:focus {
-  color: #0eb3e4;
+color: #0eb3e4;
 }
 
 
 .resize-overlay {
-    pointer-events: none;
-    position: relative;
+  pointer-events: none;
+  position: relative;
 }
 /* Styles for the navbar */
 .navbar-inverse .navbar-nav > li > a {
-    color: #fff;
-    font-weight: 400;
-    font-size: 16px;
+  color: #fff;
+  font-weight: 400;
+  font-size: 16px;
 }
 .navbar-inverse .navbar-header .navbar-brand:hover {
-    cursor: default;
-    color: #999;
+  cursor: default;
+  color: #999;
 }
 
 /* Styles for the pattern preview tool */
 #schema_holder .page-header {
-    padding-left: 60px;
+  padding-left: 60px;
 }
 #schema_holder + .alert {
-    margin: 20px 60px;
+  margin: 20px 60px;
 }
 #display_holder {
-  width: 100%;
-  border: 0;
+width: 100%;
+border: 0;
 }
 .sg-snippet-preview {
   position: relative;
@@ -88,55 +88,62 @@ a:hover, a:focus {
 }
 
 .sg-snippet-resize-handle {
-    height: 100px;
-    width: 30px;
-    margin-top: -50px;
-    position: absolute;
-    top: 50%;
-    -webkit-transition: all .4s;
-    -moz-transition: all .4s;
-    transition: all .4s;
+  height: 100px;
+  width: 30px;
+  margin-top: -50px;
+  position: absolute;
+  top: 50%;
+  -webkit-transition: all .4s;
+  -moz-transition: all .4s;
+  transition: all .4s;
 }
 
 .sg-snippet-resize-handle:before {
-    background: url('../img/icon-drag.svg') no-repeat;
-    position: absolute;
-    top: 50%;
-    content: '';
-    height: 17px;
-    margin-top: -8px;
-    width: 11px
+  background: url('../img/icon-drag.svg') no-repeat;
+  position: absolute;
+  top: 50%;
+  content: '';
+  height: 17px;
+  margin-top: -8px;
+  width: 11px
+}
+
+.sg-snippet-resize-handle.pos-right,
+.sg-snippet-resize-handle.pos-left {
+  background: rgba(192, 194, 196, 0.2);
+  height: 100%;
+  top: 0;
+  margin: 0;
+}
+
+.sg-snippet-resize-handle.pos-right::before,
+.sg-snippet-resize-handle.pos-left::before {
+  top: min(50%, 50vh);
 }
 
 .sg-snippet-resize-handle.pos-right {
-    border-right: 1px solid #ccc;
-    left: -40px;
-    cursor: e-resize;
-    background: #f8f4fe;
-    height: 98%;
-    top: 1%;
+  border-right: 1px solid #ccc;
+  left: -40px;
+  cursor: e-resize;
 }
 
-.sg-snippet-resize-handle.pos-right:before {
-    left: 10px
+.sg-snippet-resize-handle.pos-right::before {
+  left: 10px
 }
 
 .sg-snippet-resize-handle.pos-left {
-    border-left: 1px solid #ccc;
-    cursor: w-resize;
-    right: -40px;
-    background: #f8f4fe;
-    height: 98%;
-    top: 1%;
+  border-left: 1px solid #ccc;
+  right: -40px;
+  cursor: w-resize;
 }
 
 .sg-snippet-resize-handle.pos-left:before {
-    right: 10px
+  right: 10px
 }
 
 .sg-snippet:hover .sg-snippet-resize-handle {
-    opacity: 1;
-    visibility: visible
+  opacity: 1;
+  visibility: visible
 }
 
 
@@ -144,298 +151,298 @@ a:hover, a:focus {
 body { -webkit-animation: androidBugfix infinite 1s; }
 /* Layout styles for extra large browsers, side-by-side preview + data */
 @media (min-width:1800px) {
-  body, html {
-    height: 100%;
-  }
-  .left {
-    width: 50%;
-    float: left;
-    height: 100%;
-    overflow: scroll;
-  }
-  .right {
-    padding: 0 1%;
-    height: 100%;
-    left: 50%;
-    overflow: scroll;
-  }
+body, html {
+  height: 100%;
+}
+.left {
+  width: 50%;
+  float: left;
+  height: 100%;
+  overflow: scroll;
+}
+.right {
+  padding: 0 1%;
+  height: 100%;
+  left: 50%;
+  overflow: scroll;
+}
 }
 
 /* Styles specific to the schema content */
 .right {
-  background: white;
-  padding-top: 10px;
+background: white;
+padding-top: 10px;
 }
 .right > * {
-  margin-left: 10px;
-  margin-right: 10px;
-  margin-bottom: 10px;
+margin-left: 10px;
+margin-right: 10px;
+margin-bottom: 10px;
 }
 .right .nav-tabs {
-    margin-bottom: 30px;
-    padding: 0 80px;
+  margin-bottom: 30px;
+  padding: 0 80px;
 }
 @media (min-width: 1800px) {
-    .right > .container-fluid {
-        margin-top: 50px;
-    }
-    .right .nav-tabs {
-        padding-left: 10px;
-    }
+  .right > .container-fluid {
+      margin-top: 50px;
+  }
+  .right .nav-tabs {
+      padding-left: 10px;
+  }
 }
 
 /* Styles specific to the interactive schema preview */
 code {
-    color: #000000;
-    background-color: #f3e3e8;
+  color: #000000;
+  background-color: #f3e3e8;
 }
 #editor_holder {
-  font-size: 14px;
+font-size: 14px;
 }
 
 #editor_holder .btn {
-  font-size: 12px;
-  padding: 4px 8px;
+font-size: 12px;
+padding: 4px 8px;
 }
 
 #editor_holder .well > .form-control {
-  background-color: #fff !important;
-    font-size: 1.2em;
-    color: #017EA3; /* aqua */
-  font-weight: bold !important;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+background-color: #fff !important;
+  font-size: 1.2em;
+  color: #017EA3; /* aqua */
+font-weight: bold !important;
+-webkit-font-smoothing: antialiased;
+-moz-osx-font-smoothing: grayscale;
 }
 
 
 #editor_holder .list-group-item {
-  padding: 6px 6px;
+padding: 6px 6px;
 }
 
 #editor_holder .panel-title {
-    float: left;
+  float: left;
 }
 
 .page-header {
-    padding-bottom: 9px;
-    margin: 40px 10px 0px;
-    border-bottom: 1px solid #eee;
+  padding-bottom: 9px;
+  margin: 40px 10px 0px;
+  border-bottom: 1px solid #eee;
 }
 
 #editor_holder h1 {
-  font-size: 24px;
-  margin: 5px 0;
+font-size: 24px;
+margin: 5px 0;
 }
 
 #editor_holder h2 {
-  font-size: 20px;
-  margin: 8px 0;
+font-size: 20px;
+margin: 8px 0;
 }
 
 #editor_holder h3 {
-  font-size: 15px;
-  margin: 5px 0;
+font-size: 15px;
+margin: 5px 0;
 }
 
 #editor_holder p {
-  margin-bottom: 5px;
+margin-bottom: 5px;
 }
 .help-block {
-    color: #3e3e3e;
+  color: #3e3e3e;
 }
 
 .json-editor-btn-collapse {
-    background: transparent;
-    border: 0;
-    padding: 1px 3px;
-    line-height: 0;
+  background: transparent;
+  border: 0;
+  padding: 1px 3px;
+  line-height: 0;
 }
 .json-editor-btn-collapse:hover {
-    background: transparent;
+  background: transparent;
 }
 #editor_holder [data-schematype="array"]:hover > h3 .btn-group .json-editor-btn-collapse i ,
 #editor_holder [data-schematype="object"]:hover > h3 .btn-group .json-editor-btn-collapse i ,
 .json-editor-btn-collapse:hover i:before {
-    color: #017EA3; /* #276edc;*/
+  color: #017EA3; /* #276edc;*/
 }
 .json-editor-btn-collapse i {
-    font-size: 1.7em;
+  font-size: 1.7em;
 }
 
 
 #editor_holder .well {
-  margin-bottom: 10px;
+margin-bottom: 10px;
 }
 #editor_holder [data-schematype="object"] > .well,
 #editor_holder [data-schematype="object"] > .well [data-schematype="object"] > .well [data-schematype="object"] > .well,
 #editor_holder [data-schematype="object"] > .well [data-schematype="object"] > .well [data-schematype="object"] > .well [data-schematype="object"] > .well [data-schematype="object"] > .well,
 #editor_holder [data-schematype="object"] > .well [data-schematype="object"] > .well [data-schematype="object"] > .well [data-schematype="object"] > .well [data-schematype="object"] > .well [data-schematype="object"] > .well [data-schematype="object"] > .well {
-    background-color: #e6ecf0;  /* soft sky */
+  background-color: #e6ecf0;  /* soft sky */
 }
 #editor_holder [data-schematype="object"] > .well [data-schematype="object"] > .well,
 #editor_holder [data-schematype="object"] > .well [data-schematype="object"] > .well [data-schematype="object"] > .well [data-schematype="object"] > .well,
 #editor_holder [data-schematype="object"] > .well [data-schematype="object"] > .well [data-schematype="object"] > .well [data-schematype="object"] > .well [data-schematype="object"] > .well .well,
 #editor_holder [data-schematype="object"] > .well [data-schematype="object"] > .well [data-schematype="object"] > .well [data-schematype="object"] > .well [data-schematype="object"] > .well [data-schematype="object"] > .well [data-schematype="object"] > .well [data-schematype="object"] > .well {
-    background-color: #fff;
+  background-color: #fff;
 }
 #editor_holder [data-schematype="array"] .well {
-    background: transparent;;
+  background: transparent;;
 }
 
 #editor_holder [data-schematype="array"] > .well {
-    padding: 0;
-    border: 0;
+  padding: 0;
+  border: 0;
 }
 #editor_holder [data-schematype="array"] > .well > div > .well {
-  margin: 0 0 15px;
-  padding-bottom: 10px !important;
-  border: 3px solid #FFF;
-  border-radius: 0;
-  background-color: rgba(205, 233, 219, 0.3);  /* sage */
+margin: 0 0 15px;
+padding-bottom: 10px !important;
+border: 3px solid #FFF;
+border-radius: 0;
+background-color: rgba(205, 233, 219, 0.3);  /* sage */
 }
 #editor_holder [data-schematype="array"] > .well > div > .well:last-child {
-    padding-bottom: 0 !important;
+  padding-bottom: 0 !important;
 }
 #editor_holder [data-schematype="array"] > .well > div > .well label {
-    font-size: 14px;
+  font-size: 14px;
 }
 #editor_holder [data-schematype="array"] > .well > div > .well > .btn-group {
-    margin: 10px 10px 10px 0;
+  margin: 10px 10px 10px 0;
 }
 #editor_holder [data-schematype="array"] > .well > .btn-group {
-    margin: 10px;
+  margin: 10px;
 }
 #editor_holder [data-schematype="object"] > h3 span {
-    font-weight: 800;
-    color: #212121;
+  font-weight: 800;
+  color: #212121;
 }
 #editor_holder [data-schematype="object"]:hover > h3 > span,
 #editor_holder [data-schematype="object"] .well .well .well:hover h3 span {
-    color: #017EA3; /* aqua */
+  color: #017EA3; /* aqua */
 }
 #editor_holder [data-schematype="array"] > h3 span {
-    font-weight: 800;
-    color: #3E4551;
+  font-weight: 800;
+  color: #3E4551;
 },
 #editor_holder [data-schematype="array"] label {
-    font-weight: 600;
+  font-weight: 600;
 }
 #editor_holder [data-schematype="array"] > .well > div > [data-schematype="object"] {
-    border-bottom: 2px solid #fff;
+  border-bottom: 2px solid #fff;
 }
 #editor_holder [data-schematype="array"]  > .well > div > [data-schematype="object"] > h3 {
-    font-size: 14px;
-    padding-left: 10px;
-    padding-top: 5px;
+  font-size: 14px;
+  padding-left: 10px;
+  padding-top: 5px;
 }
 #editor_holder [data-schematype="array"]  > .well > div > [data-schematype="object"] > h3 span {
-    display: inline-block !important;
+  display: inline-block !important;
 }
 #editor_holder [data-schematype="array"]  > .well > div > [data-schematype="object"] > .well {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 #json_holder {
-  display: block;
-  max-width: 1400px;
-  margin: 0 auto;
+display: block;
+max-width: 1400px;
+margin: 0 auto;
 
 }
 #json_holder pre {
-  font-size: 14px;
-  font-family: monospace;
+font-size: 14px;
+font-family: monospace;
 }
 
 #json_holder .valid {
-  font-size: 14px;
-  margin-bottom: 5px;
+font-size: 14px;
+margin-bottom: 5px;
 }
 #json_holder .valid.alert-danger > br:first-child {
-    display: none;
+  display: none;
 }
 .ace_editor {
-  height: 300px !important;
+height: 300px !important;
 }
 .sceditor-container *{
-  box-sizing: content-box;
-  -moz-box-sizing: border-box;
+box-sizing: content-box;
+-moz-box-sizing: border-box;
 }
 .background {
-  display: none;
-  position: fixed;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 10;
-  background: rgba(255,255,255,.5);
+display: none;
+position: fixed;
+top: 0;
+width: 100%;
+height: 100%;
+z-index: 10;
+background: rgba(255,255,255,.5);
 }
 .well .table-bordered  {
-  border: 0px;
+border: 0px;
 }
 .well .table-bordered>thead>tr>th,
 .well .table-bordered>tbody>tr>td {
-  border: 0px;
+border: 0px;
 }
 
 .well .table-bordered>thead>tr>th ,
 .well .table-bordered>tbody>tr~tr {
-  border-top: 1px #dedede solid;
+border-top: 1px #dedede solid;
 }
 .navbar {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 .navbar + .container-fluid {
-    margin-right: 15px;
-    margin-left: 15px;
-    margin-top: 15px;
+  margin-right: 15px;
+  margin-left: 15px;
+  margin-top: 15px;
 }
 
 /* Styles specific to styleguide / documentation */
 .docs-wrapper {
-  font-size: 1.1em;
-  max-width: 800px;
+font-size: 1.1em;
+max-width: 800px;
 }
 .right, .left {
-  overflow: auto;
+overflow: auto;
 }
 .docs-wrapper a {
-  text-decoration: underline;
+text-decoration: underline;
 }
 .docs-wrapper li {
-    margin-top: 3px;
-    margin-bottom: 8px;
+  margin-top: 3px;
+  margin-bottom: 8px;
 }
 .docs-wrapper li li {
-    margin-top: 3px;
-    margin-bottom: 1px;
+  margin-top: 3px;
+  margin-bottom: 1px;
 }
 .docs-wrapper th, td {
-    border: solid 1px #ccc;
-    padding: 5px;
+  border: solid 1px #ccc;
+  padding: 5px;
 }
 
 .secondary-nav {
-    max-width: 300px;
+  max-width: 300px;
 }
 .secondary-nav + .left > *:first-child {
-  margin-top: 0;
+margin-top: 0;
 }
 .secondary-nav .nav>li {
-    margin: 0;
+  margin: 0;
 }
 .secondary-nav .nav>li>a {
-    border-bottom: 1px solid #ddd;
-    padding: 7px 3px;
+  border-bottom: 1px solid #ddd;
+  padding: 7px 3px;
 }
 code {
-    white-space: normal;
+  white-space: normal;
 }
 a[href="#top"] {
-    margin-top: -50px;
-    float: right;
+  margin-top: -50px;
+  float: right;
 }
 hr {
-    border-top: 1px solid #bbb;
-    margin-top: 30px;
-    margin-bottom: 30px;
+  border-top: 1px solid #bbb;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }


### PR DESCRIPTION
When you're on a long page like this one:
https://webrh-patternkit.int.open.paas.redhat.com/schema/pattern_page

you have to scroll down to be able to grab the handlebars to resize the window. This PR increases the height of the handles so they can be used anywhere.