### PR TITLE
feat: Adding a `body_attr` to the config

### DIFF
--- a/.pk-config.yml
+++ b/.pk-config.yml
@@ -27,6 +27,7 @@ categories:
     - Layout
     - Component
     - Atom
+body_attr:
 assets:
   css:
   js:

--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -1,3 +1,8 @@
+## 1.5 Additional config features
+Tag: [1.5](https://github.com/PatternBuilder/pattern-kit/releases/tag/V1.5)
+
+- Add support for body attributes in the config
+
 ## 1.4 Code refactor and changes to allow assets to track with the module.
 Tag: [1.4](https://github.com/PatternBuilder/pattern-kit/releases/tag/V1.4)
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ categories:
     - Atom
 body_attr:
   - unresolved
+  - class:
+    - foo
+    - bar
 assets:
   css:
     - path/to/css

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ $app['http_cache']->run();
 - Create arrays of paths to your data, schema, template, docs and styleguide files (relative to config)
 - Set the file extensions for each file type
 - List categories in order you'd like them to appear in navigation
+- Add any attributes you want printed on the body tag using `body_attr`
 - Create arrays of assets for css, js and footer js (including live reload if necessary)
 
 ```
@@ -64,6 +65,8 @@ categories:
     - Layout
     - Component
     - Atom
+body_attr:
+  - unresolved
 assets:
   css:
     - path/to/css

--- a/resources/templates/basic.twig
+++ b/resources/templates/basic.twig
@@ -7,7 +7,9 @@
                         {% set items %}
                             {% for item in attr[key] %} {{ item }}{% endfor %}
                         {% endset %}
-                    {% else %}{% set items = attr[key] ? "true" : "false" %}{% endif %}
+                    {% elseif attr[key] is same as(false) or attr[key] is same as(true) %}
+                        {% set items = attr[key] ? "true" : "false" %}
+                    {% else %}{% set items = attr[key]|trim %}{% endif %}
                     {{ key }}="{{ items|trim }}"
                 {% endfor %}
             {% else %} {{ attr }}{% endif %}

--- a/resources/templates/basic.twig
+++ b/resources/templates/basic.twig
@@ -1,3 +1,4 @@
+{% spaceless %}
 {% set body_props %}
     {%- if app_config.body_attr -%}
         {% for attr in app_config.body_attr -%}
@@ -10,6 +11,7 @@
         {%- endfor %}
     {% endif -%}
 {% endset -%}
+{% endspaceless %}
 
 <!DOCTYPE html>
 <html>

--- a/resources/templates/basic.twig
+++ b/resources/templates/basic.twig
@@ -1,17 +1,19 @@
-{% spaceless %}
 {% set body_props %}
     {%- if app_config.body_attr -%}
         {% for attr in app_config.body_attr -%}
             {% if attr is iterable -%}
                 {% for key in attr|keys %}
-                    {% set items %}{% for item in attr[ key ] %} {{ item }}{% endfor %}{% endset %}
+                    {% if attr[key] is iterable -%}
+                        {% set items %}
+                            {% for item in attr[key] %} {{ item }}{% endfor %}
+                        {% endset %}
+                    {% else %}{% set items = attr[key] ? "true" : "false" %}{% endif %}
                     {{ key }}="{{ items|trim }}"
                 {% endfor %}
             {% else %} {{ attr }}{% endif %}
         {%- endfor %}
     {% endif -%}
 {% endset -%}
-{% endspaceless %}
 
 <!DOCTYPE html>
 <html>
@@ -27,7 +29,7 @@
         <script type="text/javascript" src="{{js}}"></script>
     {% endfor %}
 </head>
-<body{{ body_props }}>
+<body{{ body_props|spaceless }}>
     <div id="snippet" data-default-overflow="scroll">
         {% if (name) or (template) %}
             {% include template ?: name ~ '.twig' %}

--- a/resources/templates/basic.twig
+++ b/resources/templates/basic.twig
@@ -29,7 +29,7 @@
         <script type="text/javascript" src="{{js}}"></script>
     {% endfor %}
 </head>
-<body{{ body_props|spaceless }}>
+<body{{ body_props }}>
     <div id="snippet" data-default-overflow="scroll">
         {% if (name) or (template) %}
             {% include template ?: name ~ '.twig' %}

--- a/resources/templates/basic.twig
+++ b/resources/templates/basic.twig
@@ -2,7 +2,10 @@
     {%- if app_config.body_attr -%}
         {% for attr in app_config.body_attr -%}
             {% if attr is iterable -%}
-                {% for key in attr|keys %} {{ key }}="{% for item in attr[ key ] %}{{ item }} {% endfor %}"{% endfor %}
+                {% for key in attr|keys %}
+                    {% set items %}{% for item in attr[ key ] %} {{ item }}{% endfor %}{% endset %}
+                    {{ key }}="{{ items|trim }}"
+                {% endfor %}
             {% else %} {{ attr }}{% endif %}
         {%- endfor %}
     {% endif -%}

--- a/resources/templates/basic.twig
+++ b/resources/templates/basic.twig
@@ -1,3 +1,13 @@
+{% set body_props %}
+    {%- if app_config.body_attr -%}
+        {% for attr in app_config.body_attr -%}
+            {% if attr is iterable -%}
+                {% for key in attr|keys %} {{ key }}="{% for item in attr[ key ] %}{{ item }} {% endfor %}"{% endfor %}
+            {% else %} {{ attr }}{% endif %}
+        {%- endfor %}
+    {% endif -%}
+{% endset -%}
+
 <!DOCTYPE html>
 <html>
 <head>
@@ -12,7 +22,7 @@
         <script type="text/javascript" src="{{js}}"></script>
     {% endfor %}
 </head>
-<body{% if app_config.body_attr %}{% for attr in app_config.body_attr %} {{ attr }}{% endfor %}{% endif %}>
+<body{{ body_props }}>
     <div id="snippet" data-default-overflow="scroll">
         {% if (name) or (template) %}
             {% include template ?: name ~ '.twig' %}

--- a/resources/templates/basic.twig
+++ b/resources/templates/basic.twig
@@ -12,7 +12,7 @@
         <script type="text/javascript" src="{{js}}"></script>
     {% endfor %}
 </head>
-<body>
+<body{% if app_config.body_attr %}{% for attr in app_config.body_attr %} {{ attr }}{% endfor %}{% endif %}>
     <div id="snippet" data-default-overflow="scroll">
         {% if (name) or (template) %}
             {% include template ?: name ~ '.twig' %}


### PR DESCRIPTION
Adding support for body attributes to the pkconfig.  This allows us to add the unresolved attribute to the body tag for web components.  It will also enable body classes to be added to replicate production environments.